### PR TITLE
Bump 'wl-pprint' dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-dist-newstyle/
 dist/
+
+# Cabal new-style artifacts
+dist-newstyle/
+cabal.project.local
+.ghc.environment.*

--- a/Expresso.cabal
+++ b/Expresso.cabal
@@ -30,7 +30,7 @@ Library
 Executable expresso
   Main-Is:         Repl.hs
   Hs-Source-Dirs:  src
-  Build-Depends:   base, containers, hashable, mtl, parsec, wl-pprint,
+  Build-Depends:   base, containers, hashable, mtl, parsec, wl-pprint >= 1.2.1,
                    unordered-containers, haskeline, directory, filepath
   Other-Modules:   Expresso.Parser
                    Expresso.Eval

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages:      Expresso.cabal
+jobs:          $ncpus
+documentation: True
+optimization:  False

--- a/src/Expresso/Pretty.hs
+++ b/src/Expresso/Pretty.hs
@@ -15,13 +15,8 @@ import Text.PrettyPrint.Leijen ( Doc, (<+>), (<//>), angles, braces, brackets
                                , int, integer, double, parens, space, text, string, vcat)
 import qualified Text.PrettyPrint.Leijen as PP
 
-
 instance IsString Doc where
   fromString = text
-
-instance Monoid Doc where
-  mempty = PP.empty
-  mappend = (PP.<>)
 
 bracketsList :: [Doc] -> Doc
 bracketsList = brackets . hsep . PP.punctuate comma


### PR DESCRIPTION
This bumps package `wl-pprint` and removes the orphan instance for `Monoid`.
