### PR TITLE
Compilation with GHC 8.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.3.0
+
+- Compilation with GHC 8.8.3
+
 ## 0.1.2.0
 
 - added type synonyms

--- a/expresso.cabal
+++ b/expresso.cabal
@@ -1,5 +1,5 @@
 Name:            expresso
-Version:         0.1.2.2
+Version:         0.1.3.0
 Cabal-Version:   >= 1.10
 License:         BSD3
 License-File:    LICENSE
@@ -37,12 +37,12 @@ Library
                     containers           >= 0.5.11 && < 0.7,
                     directory            >= 1.3.1 && < 1.4,
                     filepath             >= 1.4.2 && < 1.5,
-                    hashable             >= 1.2.7 && < 1.3,
+                    hashable             >= 1.2.7 && < 1.4,
                     text                 >= 1.2.3 && < 1.3,
                     haskeline            >= 0.7.4 && < 0.8,
                     mtl                  >= 2.2.2 && < 2.3,
                     parsec               >= 3.1.13 && < 3.2,
-                    template-haskell     >= 2.13.0 && < 2.15,
+                    template-haskell     >= 2.13.0 && < 2.16,
                     unordered-containers >= 0.2.9 && < 0.3,
                     wl-pprint            >= 1.2.1 && < 1.3
 

--- a/src/Expresso/TH/QQ.hs
+++ b/src/Expresso/TH/QQ.hs
@@ -42,7 +42,7 @@ def = QuasiQuoter
     }
   where
     failure kind =
-        fail $ "This quasi-quoter does not support splicing " ++ kind
+        error $ "This quasi-quoter does not support splicing " ++ kind
 
 genTypeAnn :: String -> ExpQ
 genTypeAnn str = do


### PR DESCRIPTION
Small fix to allow to compile with recent GHC. 

* Bump bounds
* MonadFail for reader monad is not defined, replaced with `error`